### PR TITLE
Hotfix/arreglando bootstrap

### DIFF
--- a/resources/views/admin/productos/index.blade.php
+++ b/resources/views/admin/productos/index.blade.php
@@ -69,25 +69,26 @@
                     </button>
                 </div>
                 <!-- Modal de confirmación de eliminación -->
-                <div class="modal fade" id="confirmDelete{{ $producto->id }}" tabindex="-1" aria-hidden="true">
-                    <div class="modal-dialog modal-dialog-centered">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title">Confirmar eliminación</h5>
+                <div class="modal fade fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50 hidden" id="confirmDelete{{ $producto->id }}" tabindex="-1" aria-hidden="true">
+                    <div class="modal-dialog relative top-1/4 mx-auto max-w-md">
+                        <div class="modal-content bg-white rounded-lg shadow-lg p-6">
+                            <div class="modal-header flex justify-between items-center">
+                                <h5 class="text-xl font-medium">Confirmar eliminación</h5>
                                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                             </div>
-                            <div class="modal-body">
+                            <div class="modal-body mt-4">
                                 <p>¿Estás seguro de que deseas eliminar
                                     <strong>{{ $producto->nombre_producto }}</strong>?
                                 </p>
                             </div>
-                            <div class="modal-footer">
+                            <div class="modal-footer flex justify-end mt-4 space-x-2">
                                 <form action="{{ route('productos.destroy', $producto->id) }}" method="POST">
                                     @csrf
                                     @method('DELETE')
-                                    <button type="submit" class="btn btn-danger btn-sm">Sí, eliminar</button>
+                                    <button type="submit" class="bg-red-600 hover:bg-red-700 text-white font-semibold py-1.5 px-4 rounded text-sm">
+                                        Sí, eliminar</button>
                                 </form>
-                                <button type="button" class="btn btn-secondary btn-sm"
+                                <button type="button" class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-1.5 px-4 rounded text-sm"
                                     data-bs-dismiss="modal">Cancelar</button>
                             </div>
                         </div>
@@ -96,26 +97,48 @@
 
                 <!-- Modal para ver detalles de producto (con bootstrap)-->
                 <!-- Se activará cuando se clickee el nombre del producto -->
-                <div class="modal fade" id="modal{{ $producto->id }}" tabindex="-1">
-                    <div class="modal-dialog modal-sm">
-                        <div class="modal-content">
-                            <div class="modal-header">
-                                <h5 class="modal-title"><strong>{{ $producto->nombre_producto }}</strong></h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                <!-- Modal -->
+                <div class="modal fade fixed inset-0 z-50 bg-black bg-opacity-50 hidden"
+                     id="modal{{ $producto->id }}"
+                     tabindex="-1"
+                     aria-hidden="true">
+                            
+                    <div class="modal-dialog relative mx-auto mt-24 w-full max-w-sm">
+                        <div class="modal-content bg-white rounded-lg shadow-lg overflow-hidden">
+                            
+                            <!-- Header -->
+                            <div class="modal-header flex items-center justify-between p-4 border-b">
+                                <h5 class="text-lg font-semibold text-gray-900">{{ $producto->nombre_producto }}</h5>
+                                <button type="button"
+                                        class="text-gray-500 hover:text-gray-700 focus:outline-none text-2xl font-bold"
+                                        data-bs-dismiss="modal"
+                                        aria-label="Close">
+                                    &times;
+                                </button>
                             </div>
-                            <div class="modal-body">
-                                <img src="https://placehold.co/500x500" alt=""
-                                    class="aspect-square w-full bg-gray-200 object-cover group-hover:opacity-75 xl:aspect-7/8">
-                                <p><strong>Precio:</strong> ${{ number_format($producto->precio, 0, ',', '.') }}
-                                </p>
+                            
+                            <!-- Body -->
+                            <div class="modal-body p-4 space-y-3 text-gray-800">
+                                <img src="https://placehold.co/500x500"
+                                     alt="Imagen del producto"
+                                     class="aspect-square w-full bg-gray-200 object-cover rounded">
+                                
+                                <p><strong>Precio:</strong> ${{ number_format($producto->precio, 0, ',', '.') }}</p>
                                 <p><strong>Descripción:</strong> {{ $producto->descripcion }}</p>
                             </div>
-                            <div class="modal-footer">
-                                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cerrar</button>
+                            
+                            <!-- Footer -->
+                            <div class="modal-footer flex justify-end p-4 border-t">
+                                <button type="button"
+                                        class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-2 px-4 rounded"
+                                        data-bs-dismiss="modal">
+                                    Cerrar
+                                </button>
                             </div>
                         </div>
                     </div>
                 </div>
+
             </div>
         @endforeach
     </div>

--- a/resources/views/admin/productos/index.blade.php
+++ b/resources/views/admin/productos/index.blade.php
@@ -69,7 +69,7 @@
                     </button>
                 </div>
                 <!-- Modal de confirmación de eliminación -->
-                <div class="modal fade fixed top-0 left-0 w-full h-full bg-black bg-opacity-50 z-50 hidden" id="confirmDelete{{ $producto->id }}" tabindex="-1" aria-hidden="true">
+                <div class="modal fade fixed top-0 left-0 w-full h-full bg-black/50 z-50 hidden" id="confirmDelete{{ $producto->id }}" tabindex="-1" aria-hidden="true">
                     <div class="modal-dialog relative top-1/4 mx-auto max-w-md">
                         <div class="modal-content bg-white rounded-lg shadow-lg p-6">
                             <div class="modal-header flex justify-between items-center">
@@ -98,13 +98,13 @@
                 <!-- Modal para ver detalles de producto (con bootstrap)-->
                 <!-- Se activará cuando se clickee el nombre del producto -->
                 <!-- Modal -->
-                <div class="modal fade fixed inset-0 z-50 bg-black bg-opacity-50 hidden"
+                <div class="modal fade fixed inset-0 z-50 bg-black/50 hidden"
                      id="modal{{ $producto->id }}"
                      tabindex="-1"
                      aria-hidden="true">
                             
                     <div class="modal-dialog relative mx-auto mt-24 w-full max-w-sm">
-                        <div class="modal-content bg-white rounded-lg shadow-lg overflow-hidden">
+                        <div class="modal-content bg-white rounded-lg shadow-lg max-h-[80vh] overflow-y-auto">
                             
                             <!-- Header -->
                             <div class="modal-header flex items-center justify-between p-4 border-b">

--- a/resources/views/components/layouts/panel.blade.php
+++ b/resources/views/components/layouts/panel.blade.php
@@ -4,8 +4,6 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Panel de Administracion</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/css/bootstrap.min.css" rel="stylesheet"
-        integrity="sha384-SgOJa3DmI69IUzQ2PVdRZhwQ+dy64/BUtbMJw1MZ8t5HZApcHrRKUc4W0kG879m7" crossorigin="anonymous">
     @vite('resources/css/app.css')
 </head>
 <body>
@@ -32,9 +30,7 @@
             {{ $slot }}
         </main>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
-        integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous">
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"</script>
     <!-- Este script es para colocarle signo peso y puntos a los input precio -->
     <script>
         document.addEventListener('DOMContentLoaded', function () {

--- a/resources/views/components/layouts/panel.blade.php
+++ b/resources/views/components/layouts/panel.blade.php
@@ -30,7 +30,9 @@
             {{ $slot }}
         </main>
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"</script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.5/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-k6d4wzSIapyDyv1kpU366/PK5hCdSbCRGRCMv+eplOQJWyd1fbcAu9OCUj5zNLiq" crossorigin="anonymous">
+    </script>
     <!-- Este script es para colocarle signo peso y puntos a los input precio -->
     <script>
         document.addEventListener('DOMContentLoaded', function () {


### PR DESCRIPTION
Se arregló conflicto entre Tailwindcss y Bootstrap css, solo quedaron las funcionalidades js de bootstrap con su script.
**Importante** No hay que colocar link a bootstrap css en header, solo usar tailwind para estilos. Por ultimo pedirle a chatgpt que simule estilos de bootstrap con tailwindcss xd.