### PR TITLE
Feature/actualizar metodo registra accion

### DIFF
--- a/app/Http/Controllers/AdministradoresController.php
+++ b/app/Http/Controllers/AdministradoresController.php
@@ -47,7 +47,9 @@ class AdministradoresController extends Controller
 
         $admin = Administrador::create($atributos);
 
-        Registro::registrar_accion($admin, 'administrador', 5);
+        Registro::registrar_accion($admin, 'Crea un nuevo admin');
+
+        session()->flash('success', 'Nuevo admin creado');
 
         return redirect('/admin/administradores');
     }
@@ -102,7 +104,9 @@ class AdministradoresController extends Controller
             'correo_admin' => request('correo_admin'),
         ]);
 
-        Registro::registrar_accion($administrador, 'administrador', 6);
+        Registro::registrar_accion($administrador, 'Edita los datos de un admin');
+
+        session()->flash('success', 'Datos actualizados');
 
         return redirect('/admin/administradores');
     }
@@ -146,7 +150,9 @@ class AdministradoresController extends Controller
         // Actualizamos la tabla pivote: se eliminan los que no estén, se agregan los nuevos
         $administrador->permisos()->sync($permisosActivos);
 
-        // Registro::registrar_accion($administrador, 'administrador', 6);
+        Registro::registrar_accion($administrador, 'Edita los permisos de un admin');
+
+        session()->flash('success', 'Permisos Actualizados');
 
         return redirect()->back();
     }

--- a/app/Http/Controllers/AdministradoresController.php
+++ b/app/Http/Controllers/AdministradoresController.php
@@ -120,12 +120,17 @@ class AdministradoresController extends Controller
         return redirect('/admin/administradores');
     }
 
-    /**
-     * Remove the specified resource from storage.
-     */
-    public function destroy(Administrador $administrador)
+    public function disable(Administrador $administrador)
     {
-        //
+        if (request()->user('admin')->cannot('disable', Administrador::class)) { abort(403); }
+
+        if ($administrador->activo) {
+            $administrador->update(['activo' => false]);
+        } else {
+            $administrador->update(['activo' => true]);
+        }
+
+        return redirect('/admin/administradores');
     }
 
     public function edit_permisos(Administrador $administrador)

--- a/app/Http/Controllers/AdministradoresController.php
+++ b/app/Http/Controllers/AdministradoresController.php
@@ -29,10 +29,11 @@ class AdministradoresController extends Controller
         return view('admin.administradores.index', compact('administradores'));
     }
 
-
     public function create(Request $request)
     {
-        if (request()->user('admin')->cannot('create', Administrador::class)) { abort(403); }
+        if (request()->user('admin')->cannot('create', Administrador::class)) {
+            abort(403);
+        }
 
         return view('admin.administradores.create');
     }
@@ -85,14 +86,18 @@ class AdministradoresController extends Controller
 
     public function edit(Administrador $administrador)
     {
-        if (request()->user('admin')->cannot('update', Administrador::class)) { abort(403); }
+        if (request()->user('admin')->cannot('update', Administrador::class)) {
+            abort(403);
+        }
 
         return view('admin.administradores.edit', ['admin' => $administrador]);
     }
 
     public function update(Administrador $administrador)
     {
-        if (request()->user('admin')->cannot('update', Administrador::class)) { abort(403); }
+        if (request()->user('admin')->cannot('update', Administrador::class)) {
+            abort(403);
+        }
 
         request()->validate([
             'nombre_admin' => ['required', 'string', 'max:255', Rule::unique('administradores')->ignore($administrador->id)],
@@ -121,9 +126,13 @@ class AdministradoresController extends Controller
 
     public function edit_permisos(Administrador $administrador)
     {
-        if ($administrador->superadmin) { abort(403, 'No se pueden editar los permisos de un SuperAdmin'); }
+        if ($administrador->superadmin) {
+            abort(403, 'No se pueden editar los permisos de un SuperAdmin');
+        }
 
-        if (request()->user('admin')->cannot('update_permisos', Administrador::class)) { abort(403); }
+        if (request()->user('admin')->cannot('update_permisos', Administrador::class)) {
+            abort(403);
+        }
 
         $permisos_asignados = $administrador->permisos()->pluck('id');
         $permisos = Permisos::all()->groupBy('categoria_permiso');
@@ -137,7 +146,9 @@ class AdministradoresController extends Controller
 
     public function update_permisos(Administrador $administrador)
     {
-        if (request()->user('admin')->cannot('update_permisos', Administrador::class)) { abort(403); }
+        if (request()->user('admin')->cannot('update_permisos', Administrador::class)) {
+            abort(403);
+        }
 
         request()->validate([
             'permisos'   => ['nullable', 'array'], // los permisos recibidos vienen en un array
@@ -145,7 +156,15 @@ class AdministradoresController extends Controller
         ]);
 
         // Obtenemos solo los IDs de los permisos activos desde el form (los checkboxes marcados)
-        $permisosActivos = request()->input('permisos', []); // si no hay ninguno, será un array vacío
+        $permisosActivos = array_map('intval', request()->input('permisos', [])); // si no hay ninguno, será un array vacío
+
+        if ( !in_array(1, $permisosActivos) && collect($permisosActivos)->intersect([2, 3, 4, 5])->isNotEmpty()) {
+            session()->flash('warning', 'El permiso [Ver Todos Los Productos] está desactivado, pero tienes permisos específicos habilitados, por lo que el administrador no podrá acceder a algunas funciones normalmente.');
+        }
+        if ( !in_array(6, $permisosActivos) && collect($permisosActivos)->intersect([7,8,9,10,11,12])->isNotEmpty()) {
+            session()->flash('warning', 'El permiso [Ver Todos Los Admin] está desactivado, pero tienes permisos específicos habilitados, por lo que el administrador no podrá acceder a algunas funciones normalmente.');
+        }
+
 
         // Actualizamos la tabla pivote: se eliminan los que no estén, se agregan los nuevos
         $administrador->permisos()->sync($permisosActivos);

--- a/app/Http/Controllers/AdministradoresController.php
+++ b/app/Http/Controllers/AdministradoresController.php
@@ -78,9 +78,12 @@ class AdministradoresController extends Controller
             return $registro->accion_id === 1;
         })->fecha_registro ?? 'No ha accedido aún';
 
+        $permisos_actuales = $administrador->permisos()->get()->groupBy('categoria_permiso');
+
         return view('admin.administradores.show', [
-            'admin'     => $administrador,
-            'registros' => $registros,
+            'admin'             => $administrador,
+            'permisos_actuales' => $permisos_actuales,
+            'registros'         => $registros,
         ]);
     }
 
@@ -158,13 +161,12 @@ class AdministradoresController extends Controller
         // Obtenemos solo los IDs de los permisos activos desde el form (los checkboxes marcados)
         $permisosActivos = array_map('intval', request()->input('permisos', [])); // si no hay ninguno, será un array vacío
 
-        if ( !in_array(1, $permisosActivos) && collect($permisosActivos)->intersect([2, 3, 4, 5])->isNotEmpty()) {
+        if (! in_array(1, $permisosActivos) && collect($permisosActivos)->intersect([2, 3, 4, 5])->isNotEmpty()) {
             session()->flash('warning', 'El permiso [Ver Todos Los Productos] está desactivado, pero tienes permisos específicos habilitados, por lo que el administrador no podrá acceder a algunas funciones normalmente.');
         }
-        if ( !in_array(6, $permisosActivos) && collect($permisosActivos)->intersect([7,8,9,10,11,12])->isNotEmpty()) {
+        if (! in_array(6, $permisosActivos) && collect($permisosActivos)->intersect([7, 8, 9, 10, 11, 12])->isNotEmpty()) {
             session()->flash('warning', 'El permiso [Ver Todos Los Admin] está desactivado, pero tienes permisos específicos habilitados, por lo que el administrador no podrá acceder a algunas funciones normalmente.');
         }
-
 
         // Actualizamos la tabla pivote: se eliminan los que no estén, se agregan los nuevos
         $administrador->permisos()->sync($permisosActivos);

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -3,27 +3,33 @@
 namespace App\Http\Controllers;
 
 use App\Models\Categoria;
-use App\Models\Producto;
 use App\Models\Registro;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\File;
 use Illuminate\Validation\Rule;
 
 class CategoriaController extends Controller
 {
     public function index(Request $request)
     {
+        if (request()->user('admin')->cannot('viewAny', Categoria::class)) {
+            return view('admin.categorias.index'); // salir sin enviar datos
+        }
+
         $categorias = Categoria::all();
         return view('admin.categorias.index', compact('categorias'));
     }
 
     public function create()
     {
+        if (request()->user('admin')->cannot('create', Categoria::class)) { abort(403); }
+
         return view('admin.categorias.create');
     }
 
     public function store(Request $request)
     {
+        if (request()->user('admin')->cannot('create', Categoria::class)) { abort(403); }
+
         $request->validate([
             'nombre_categoria'      => ['required', 'max:250', 'unique:categorias'],
             'descripcion_categoria' => [],
@@ -43,11 +49,15 @@ class CategoriaController extends Controller
 
     public function edit(Categoria $categoria)
     {
+        if (request()->user('admin')->cannot('update', Categoria::class)) { abort(403); }
+
         return view('admin.categorias.edit', compact('categoria'));
     }
 
     public function update(Request $request, Categoria $categoria)
     {
+        if (request()->user('admin')->cannot('update', Categoria::class)) { abort(403); }
+
         $request->validate([
             'nombre_categoria' => ['required', 'max:250', Rule::unique('categorias')->ignore($categoria->id)],
             'descripcion_categoria' => [],
@@ -67,6 +77,8 @@ class CategoriaController extends Controller
 
     public function destroy(Categoria $categoria)
     {
+        if (request()->user('admin')->cannot('delete', Categoria::class)) { abort(403); }
+
         $categoria->delete();
 
         Registro::registrar_accion($categoria, 'Elimina una categoría');

--- a/app/Http/Controllers/CategoriaController.php
+++ b/app/Http/Controllers/CategoriaController.php
@@ -26,7 +26,7 @@ class CategoriaController extends Controller
     {
         $request->validate([
             'nombre_categoria'      => ['required', 'max:250', 'unique:categorias'],
-            'descripcion_categoria' => [], 
+            'descripcion_categoria' => [],
         ]);
 
         $categoria = Categoria::create([
@@ -34,9 +34,9 @@ class CategoriaController extends Controller
             'descripcion_categoria' => request('descripcion_categoria'),
         ]);
 
-        Registro::registrar_accion($categoria, 'categorias', 3);
+        Registro::registrar_accion($categoria, 'Crea nueva categoría');
 
-        session()->flash('success_create', 'Categoría creada exitosamente!');
+        session()->flash('success', 'Categoría creada exitosamente!');
 
         return redirect('/admin/categorias/');
     }
@@ -50,7 +50,7 @@ class CategoriaController extends Controller
     {
         $request->validate([
             'nombre_categoria' => ['required', 'max:250', Rule::unique('categorias')->ignore($categoria->id)],
-            'descripcion_categoria' => [], 
+            'descripcion_categoria' => [],
         ]);
 
         $categoria->update([
@@ -58,8 +58,9 @@ class CategoriaController extends Controller
             'descripcion_categoria' => $request->input('descripcion_categoria'),
         ]);
 
-        Registro::registrar_accion($categoria, 'categorias', 4);
-        session()->flash('success_update', 'Categoría actualizada exitosamente!');
+        Registro::registrar_accion($categoria, 'Edita una categoría');
+
+        session()->flash('success', 'Categoría actualizada exitosamente!');
 
         return redirect()->route('categorias.index');
     }
@@ -67,7 +68,11 @@ class CategoriaController extends Controller
     public function destroy(Categoria $categoria)
     {
         $categoria->delete();
-        session()->flash('success_delete', '¡Categoría eliminada exitosamente!');
+
+        Registro::registrar_accion($categoria, 'Elimina una categoría');
+
+        session()->flash('success', '¡Categoría eliminada exitosamente!');
+
         return redirect()->route('categorias.index');
     }
 }

--- a/app/Http/Controllers/MovimientosController.php
+++ b/app/Http/Controllers/MovimientosController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\MotivoMovimiento;
 use App\Models\Movimiento;
 use App\Models\Producto;
+use App\Models\Registro;
 use Illuminate\Http\Request;
 
 class MovimientosController extends Controller
@@ -44,6 +45,8 @@ class MovimientosController extends Controller
         ]);
 
         $producto->update(['stock_actual' => $producto->stock_actual - $cantidad]);
+
+        Registro::registrar_accion($producto, 'Vende un producto');
 
         return redirect('/admin/productos/');
     }

--- a/app/Http/Controllers/ProductoController.php
+++ b/app/Http/Controllers/ProductoController.php
@@ -14,7 +14,7 @@ class ProductoController extends Controller
 {
     public function index(Request $request)
     {
-        if (request()->user('admin')->cannot('create', Producto::class)) {
+        if (request()->user('admin')->cannot('viewAny', Producto::class)) {
             return view('admin.productos.index'); // salir sin enviar datos
         }
 

--- a/app/Http/Controllers/ProductoController.php
+++ b/app/Http/Controllers/ProductoController.php
@@ -72,9 +72,9 @@ class ProductoController extends Controller
         ]);
 
         // registrar acción del admin
-        Registro::registrar_accion($producto, 'productos', 3);
+        Registro::registrar_accion($producto, 'Crea nuevo producto');
 
-        session()->flash('success_create', '¡Producto creado exitosamente!');
+        session()->flash('success', '¡Producto creado exitosamente!');
 
         return redirect('/admin/productos/');
     }
@@ -120,7 +120,7 @@ class ProductoController extends Controller
         if ($request->imagen) {
             $imagen_url = $request->imagen->store('images/productos');
 
-            if (Storage::exists($producto->imagen_url))
+            if ($producto->imagen_url && Storage::exists($producto->imagen_url))
                 Storage::delete($producto->imagen_url);
         }
 
@@ -133,9 +133,9 @@ class ProductoController extends Controller
             'imagen_url'      => $imagen_url ?? $producto->imagen_url,
         ]);
 
-        Registro::registrar_accion($producto, 'productos', 4);
+        Registro::registrar_accion($producto, 'Edita un producto');
 
-        session()->flash('success_update', '¡Producto actualizado exitosamente!');
+        session()->flash('success', '¡Producto actualizado exitosamente!');
 
         return redirect()->route('productos.index');
     }
@@ -149,7 +149,9 @@ class ProductoController extends Controller
 
         $producto->delete();
 
-        session()->flash('success_delete', '¡Producto eliminado exitosamente!');
+        Registro::registrar_accion($producto, 'Elimina un producto');
+
+        session()->flash('success', '¡Producto eliminado exitosamente!');
 
         return redirect()->route('productos.index');
     }

--- a/app/Http/Controllers/UsuariosController.php
+++ b/app/Http/Controllers/UsuariosController.php
@@ -39,7 +39,9 @@ class UsuariosController extends Controller
 
         $user = User::create($atributos);
 
-        Registro::registrar_accion($user, 'users', 5); // acción: creación
+        Registro::registrar_accion($user, 'Crea un nuevo usuario cliente'); // acción: creación
+
+        session()->flash('success', 'Usuario creado exitosamente!');
 
         return redirect('/admin/usuarios');
     }
@@ -60,7 +62,7 @@ class UsuariosController extends Controller
             return $registro->accion_id === 1;
         });
         $usuario['ultimo_login'] = $ultimo_login ? $ultimo_login->fecha_registro : null;
-        
+
         return view('admin.usuarios.show', [
             'usuario'   => $usuario,
             'registros' => $registros,
@@ -84,7 +86,9 @@ class UsuariosController extends Controller
             'email' => $request->input('email'),
         ]);
 
-        Registro::registrar_accion($usuario, 'users', 6); // acción: edición
+        Registro::registrar_accion($usuario, 'Edita un usuario cliente'); // acción: edición
+
+        session()->flash('success', 'Usuario actualizado exitosamente!');
 
         return redirect('/admin/usuarios');
     }
@@ -93,7 +97,9 @@ class UsuariosController extends Controller
     {
         $usuario->delete();
 
-        //Registro::registrar_accion($usuario, 'users', 7); // acción: eliminación
+        Registro::registrar_accion($usuario, 'Elimina un usuario cliente'); // acción: eliminación
+
+        session()->flash('success', 'Usuario Eliminado exitosamente!');
 
         return redirect('/admin/usuarios');
     }

--- a/app/Livewire/Actions/LogoutAdmin.php
+++ b/app/Livewire/Actions/LogoutAdmin.php
@@ -13,7 +13,7 @@ class LogoutAdmin
      */
     public function __invoke()
     {
-        Registro::registrar_accion(null, null, 2);
+        Registro::registrar_accion(null, 'Cierra sesión');
 
         Auth::guard('admin')->logout();
 

--- a/app/Livewire/Auth/AdminLogin.php
+++ b/app/Livewire/Auth/AdminLogin.php
@@ -41,7 +41,7 @@ class AdminLogin extends Component
         Session::regenerate();
 
         // registrar login del usuario
-        Registro::registrar_accion(null, null, 1);
+        Registro::registrar_accion(null, 'Inicia sesión');
 
         $this->redirectIntended(default: route('login-admin', absolute: false), navigate: false);
     }

--- a/app/Models/Administrador.php
+++ b/app/Models/Administrador.php
@@ -29,6 +29,8 @@ class Administrador extends Authenticatable
 
     public function tiene_permiso(string $nombre)
     {
+        if ($this->id === 1) { return true; }
+
         return $this->permisos->contains('nombre_permiso', $nombre);
     }
 

--- a/app/Policies/CategoriaPolicy.php
+++ b/app/Policies/CategoriaPolicy.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Administrador;
+use App\Models\Categoria;
+
+class CategoriaPolicy
+{
+    public function viewAny(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Ver Todas Las Categorias');
+    }
+
+    public function create(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Crear Categorias');
+    }
+
+    public function update(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Editar Categorias');
+    }
+
+    public function delete(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Eliminar Categorias');
+    }
+}

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Administrador;
+use App\Models\User;
+use Illuminate\Auth\Access\Response;
+
+class UserPolicy
+{
+    public function viewAny(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Ver Todos Los Usuarios');
+    }
+
+    public function view(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Ver Detalles De Un Usuario');
+    }
+
+    public function create(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Crear Usuarios');
+    }
+
+    public function update(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Editar Usuarios');
+    }
+
+    public function disable(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Desactivar Usuarios');
+    }
+
+    public function delete(Administrador $admin): bool
+    {
+        return $admin->tiene_permiso('Eliminar Usuarios');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,8 @@
 
 namespace App\Providers;
 
+use App\Models\Administrador;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -19,6 +21,8 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Gate::define('admin-activo', function (Administrador $admin) {
+            return $admin->activo;
+        });
     }
 }

--- a/database/seeders/PermisoSeeder.php
+++ b/database/seeders/PermisoSeeder.php
@@ -34,6 +34,14 @@ class PermisoSeeder extends Seeder
             ['nombre_permiso' => 'Crear Categorias', 'categoria_permiso' => 'Categorias'],
             ['nombre_permiso' => 'Editar Categorias', 'categoria_permiso' => 'Categorias'],
             ['nombre_permiso' => 'Eliminar Categorias', 'categoria_permiso' => 'Categorias'],
+
+            // Permisos Edición de Usuarios
+            ['nombre_permiso' => 'Ver Todos Los Usuarios', 'categoria_permiso' => 'Usuarios'],
+            ['nombre_permiso' => 'Ver Detalles De Un Usuario', 'categoria_permiso' => 'Usuarios'],
+            ['nombre_permiso' => 'Crear Usuarios', 'categoria_permiso' => 'Usuarios'],
+            ['nombre_permiso' => 'Editar Usuarios', 'categoria_permiso' => 'Usuarios'],
+            ['nombre_permiso' => 'Desactivar Usuarios', 'categoria_permiso' => 'Usuarios'],
+            ['nombre_permiso' => 'Eliminar Usuarios', 'categoria_permiso' => 'Usuarios'],
         ];
 
         foreach ($permisos as $permiso) {

--- a/database/seeders/PermisoSeeder.php
+++ b/database/seeders/PermisoSeeder.php
@@ -28,6 +28,12 @@ class PermisoSeeder extends Seeder
             ['nombre_permiso' => 'Editar Permisos Admin', 'categoria_permiso' => 'Admin'],
             ['nombre_permiso' => 'Desactivar Admin', 'categoria_permiso' => 'Admin'],
             ['nombre_permiso' => 'Eliminar Admin', 'categoria_permiso' => 'Admin'],
+
+            // Permisos de Categorias
+            ['nombre_permiso' => 'Ver Todas Las Categorias', 'categoria_permiso' => 'Categorias'],
+            ['nombre_permiso' => 'Crear Categorias', 'categoria_permiso' => 'Categorias'],
+            ['nombre_permiso' => 'Editar Categorias', 'categoria_permiso' => 'Categorias'],
+            ['nombre_permiso' => 'Eliminar Categorias', 'categoria_permiso' => 'Categorias'],
         ];
 
         foreach ($permisos as $permiso) {

--- a/resources/views/admin/administradores/activo.blade.php
+++ b/resources/views/admin/administradores/activo.blade.php
@@ -1,5 +1,0 @@
-<x-layouts.navlist-show-admins :admin="$admin">
-
-
-
-</x-layouts.navlist-show-admins>

--- a/resources/views/admin/administradores/activo.blade.php
+++ b/resources/views/admin/administradores/activo.blade.php
@@ -1,0 +1,5 @@
+<x-layouts.navlist-show-admins :admin="$admin">
+
+
+
+</x-layouts.navlist-show-admins>

--- a/resources/views/admin/administradores/delete.blade.php
+++ b/resources/views/admin/administradores/delete.blade.php
@@ -1,0 +1,41 @@
+<x-layouts.navlist-show-admins :admin="$admin">
+
+    @if (session('failure'))
+        <x-mensaje-accion icon="x-circle" variant="danger" heading="{{ session('failure') }}" />
+    @endif
+
+    <h2 class="text-2xl font-bold text-[#3D3C63] mb-2">Eliminar este administrador</h2>
+    <p class="text-melocoton mb-4">Pulse el botón para eliminar este administrador</p>
+
+    <flux:modal.trigger name="edit-profile">
+        <flux:button class="mt-10" variant='danger'>Eliminar Administrador Permanentemente</flux:button>
+    </flux:modal.trigger>
+
+    <flux:modal name="edit-profile" class="w-96 md:w-125">
+        <form method="POST" action="{{ route('administradores.destroy', $admin->id) }}">
+            @csrf
+            @method('DELETE')
+
+            <div class="space-y-6">
+                <div>
+                    <h2 class="text-2xl font-bold text-center text-[#3D3C63] mb-4">¿Seguro que quieres eliminar este
+                        Administrador?</h2>
+                    <p class="text-melocoton mb-4 font-semibold">Esta cambio es irreversible.</p>
+                    <p class="text-melocoton mb-4 font-semibold">Para confirmar que quieres eliminiar este
+                        administrador, escribe su nombre exacto en el siguiente campo:</p>
+                </div>
+
+                <flux:input name="nombre_admin" label="Nombre del administrador" autofocus
+                    placeholder="{{ $admin->nombre_admin }}" />
+
+                <div class="flex gap-2">
+                    <flux:spacer />
+                    <flux:modal.close>
+                        <flux:button variant="ghost">Cancel</flux:button>
+                    </flux:modal.close>
+                    <flux:button type="submit" variant="danger">Confirmar</flux:button>
+                </div>
+            </div>
+        </form>
+    </flux:modal>
+</x-layouts.navlist-show-admins>

--- a/resources/views/admin/administradores/edit-permisos.blade.php
+++ b/resources/views/admin/administradores/edit-permisos.blade.php
@@ -1,19 +1,29 @@
 <x-layouts.navlist-show-admins :admin="$admin">
-
-    @if (session('success_update'))
-        <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success_update') }}"/>
-    @endif
-    @if (session('warning'))
-        <x-mensaje-accion icon="exclamation-triangle" variant="warning" heading="{{ session('warning') }}"/>
-    @endif
-
-    <h2 class="text-2xl font-bold text-[#3D3C63] mb-2">Editor de permisos</h2>
-    <p class="text-melocoton mb-4">Seleccione los permisos que tendrá el administrador y confirme los cambios</p>
-
     <form method="POST" action="{{ route('administradores.update-permisos', $admin->id) }}">
         @csrf
         @method('PUT')
 
+        @if (session('success'))
+            <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success_update') }}" />
+        @endif
+        @if (session('warning'))
+            <x-mensaje-accion icon="exclamation-triangle" variant="warning" heading="{{ session('warning') }}" />
+        @endif
+        @if ($errors->any())
+            <x-forms.error-card />
+        @endif
+
+        <div class="flex items-center justify-between">
+            <div>
+                <h2 class="text-2xl font-bold text-[#3D3C63] mb-2">Editor de permisos</h2>
+                <p class="text-melocoton mb-4">Seleccione los permisos que tendrá el administrador y confirme los
+                    cambios</p>
+            </div>
+            <flux:button type="submit" variant="primary" icon="arrow-path"
+                class="bg-verde-oliva hover:bg-verde-oliva/70! dark:text-black! dark:bg-white! rounded-3xl!">
+                Aplicar Permisos
+            </flux:button>
+        </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-6">
             @foreach ($permisos as $categoria_permiso => $categorias_permiso)
@@ -37,19 +47,6 @@
                     </div>
                 </div>
             @endforeach
-        </div>
-
-        <div class="flex flex-col gap-6 mt-6">
-
-            @if ($errors->any())
-                <x-forms.error-card />
-            @endif
-
-            <div class="flex items-center justify-end gap-x-6">
-                <flux:button type="submit" variant="primary" icon="arrow-path"
-                    class="bg-verde-oliva hover:bg-verde-oliva/70! dark:text-black! dark:bg-white! rounded-3xl!">Editar
-                    Permisos</flux:button>
-            </div>
         </div>
 
     </form>

--- a/resources/views/admin/administradores/edit-permisos.blade.php
+++ b/resources/views/admin/administradores/edit-permisos.blade.php
@@ -1,8 +1,11 @@
 <x-layouts.navlist-show-admins :admin="$admin">
 
+    @if (session('success_update'))
+        <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success_update') }}"/>
+    @endif
+
     <h2 class="text-2xl font-bold text-[#3D3C63] mb-2">Editor de permisos</h2>
     <p class="text-melocoton mb-4">Seleccione los permisos que tendrá el administrador y confirme los cambios</p>
-
 
     <form method="POST" action="{{ route('administradores.update-permisos', $admin->id) }}">
         @csrf
@@ -20,8 +23,10 @@
                     <!-- Lista de permisos -->
                     <div class="space-y-2 px-4 py-3">
                         @foreach ($categorias_permiso as $permiso)
-                            <label class="flex items-center border rounded-full px-4 py-2 bg-white text-azul-profundo text-sm cursor-pointer hover:bg-gray-50 transition duration-150">
-                                <input type="checkbox" name="permisos[]" value="{{ $permiso->id }}" {{ $permisos_asignados->contains($permiso->id) ? 'checked' : '' }}
+                            <label
+                                class="flex items-center border rounded-full px-4 py-2 bg-white text-azul-profundo text-sm cursor-pointer hover:bg-gray-50 transition duration-150">
+                                <input type="checkbox" name="permisos[]" value="{{ $permiso->id }}"
+                                    {{ $permisos_asignados->contains($permiso->id) ? 'checked' : '' }}
                                     class="form-checkbox w-4 h-4 mr-2 accent-verde-oliva">
                                 {{ $permiso->nombre_permiso }}
                             </label>

--- a/resources/views/admin/administradores/edit-permisos.blade.php
+++ b/resources/views/admin/administradores/edit-permisos.blade.php
@@ -3,6 +3,9 @@
     @if (session('success_update'))
         <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success_update') }}"/>
     @endif
+    @if (session('warning'))
+        <x-mensaje-accion icon="exclamation-triangle" variant="warning" heading="{{ session('warning') }}"/>
+    @endif
 
     <h2 class="text-2xl font-bold text-[#3D3C63] mb-2">Editor de permisos</h2>
     <p class="text-melocoton mb-4">Seleccione los permisos que tendrá el administrador y confirme los cambios</p>

--- a/resources/views/admin/administradores/index-historial.blade.php
+++ b/resources/views/admin/administradores/index-historial.blade.php
@@ -1,0 +1,68 @@
+<x-layouts.navlist-show-admins :admin="$admin">
+
+    <h2 class="mb-4 text-2xl text-azul-profundo font-bold">Historial de Acciones</h2>
+
+    <form method="GET" class="mb-6 grid md:grid-cols-4 gap-4 items-end">
+        <flux:select name="accion" label="Acción">
+            <option value="">Todas</option>
+            @foreach ($acciones as $accion)
+                <option value="{{ $accion }}" @selected(request('accion') == $accion)>
+                    {{ $accion }}
+                </option>
+            @endforeach
+        </flux:select>
+
+        <flux:select name="entidad" label="Entidad Modificada">
+            <option value="">Todas</option>
+            <option value="sin_entidad" @selected(request('entidad') == 'sin_entidad')>Sin entidad</option>
+            @foreach ($entidades as $entidad)
+                <option value="{{ $entidad }}" @selected(request('entidad') == $entidad)>{{ $entidad }}</option>
+            @endforeach
+        </flux:select>
+
+        <flux:input type="date" name="desde" value="{{ request('desde') }}" max="2999-12-31" label="Desde" />
+
+        <flux:input type="date" name="hasta" value="{{ request('hasta') }}" max="2999-12-31" label="Hasta" />
+
+        <div class="md:col-span-4 flex justify-end space-x-2">
+            <flux:button type="submit" class="bg-verde-oliva!" variant="primary">Filtrar</flux:button>
+            <flux:button href="{{ route('administradores.historial', $admin->id) }}">Limpiar</flux:button>
+        </div>
+    </form>
+
+    <div class="mt-4">
+        {{ $registros->withQueryString()->links() }}
+    </div>
+
+    @can('view', App\Models\Administrador::class)
+        <div class="mt-4 overflow-hidden rounded-lg border-1">
+            <table class="min-w-full border-separate border-spacing-0 text-sm">
+                <thead class="bg-gray-200 text-azul-profundo">
+                    <tr>
+                        <th class="px-4 py-2 text-left">Acción</th>
+                        <th class="px-4 py-2 text-left">Entidad Modificada</th>
+                        <th class="px-4 py-2 text-left">Datos</th>
+                        <th class="px-4 py-2 text-left">Fecha Registro</th>
+                    </tr>
+                </thead>
+                <tbody class="bg-white text-[#3D3C63]">
+                    @foreach ($registros as $registro)
+                        <tr class="hover:bg-[#FAFAFA]">
+                            <td class="px-4 py-2">{{ $registro->accion->nombre_accion }}</td>
+                            <td class="px-4 py-2">{{ $registro->entidad_modificada ?? '---' }}</td>
+                            <td class="px-4 py-2">{{ $registro->id_entidad_modificada ?? '---' }}</td>
+                            <td class="px-4 py-2">{{ $registro->fecha_registro }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    @else
+        <div class="flex items-center justify-center h-64">
+            <div class="text-center">
+                <p class="text-lg font-semibold text-gray-600">No tienes permiso para ver los detalles de un administrador.
+                </p>
+            </div>
+        </div>
+    @endcan
+</x-layouts.navlist-show-admins>

--- a/resources/views/admin/administradores/index.blade.php
+++ b/resources/views/admin/administradores/index.blade.php
@@ -34,6 +34,7 @@
                             <th class="p-2 font-semibold tracking-wide text-left">Último Cambio</th>
                             <th class="p-2 font-semibold tracking-wide text-left">Creación</th>
                             <th class="p-2 font-semibold tracking-wide text-left">Activo</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">Super Admin</th>
                             <th class="p-2 font-semibold tracking-wide text-right">Acciones Rápidas</th>
                         </tr>
                     </thead>
@@ -47,6 +48,7 @@
                                     {{ $admin->ultimo_cambio ?? 'No ha hecho cambios aún' }}</td>
                                 <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->created_at }}</td>
                                 <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->activo ? 'Si' : 'No' }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->superadmin ? 'Si' : 'No' }}</td>
                                 <td class="p-3 text-gray-700 whitespace-nowrap text-right space-x-2">
                                     <flux:button href="{{ route('administradores.show', $admin->id) }}" tooltip="Detalles"
                                         icon="list-bullet" class="text-blue-600!" />
@@ -55,8 +57,9 @@
                                         <flux:button href="{{ route('administradores.edit', $admin->id) }}"
                                             tooltip="Editar Datos" icon="pencil-square" class="text-blue-600!" />
                                     @endcan
-                                    @can('disable', App\Models\Administrador::class)
-                                        <flux:button tooltip="Desactivar Admin" icon="eye-slash" class="text-red-600!" />
+                                    @can('view', App\Models\Administrador::class)
+                                        <flux:button href="{{ route('administradores.historial', $admin->id) }}"
+                                            tooltip="Historial de Acciones" icon="clock" class="text-blue-600!" />
                                     @endcan
                                 </td>
                             </tr>
@@ -75,11 +78,16 @@
                                     {{ $admin->nombre_admin }}</h2>
                                 <p class="text-sm text-gray-500">{{ $admin->correo_admin }}</p>
                             </div>
+                        </div>
+
+                        <div class="space-x-2">
                             <span
-                                class="px-2 py-1 text-sm rounded-full
-                    {{ $admin->activo ? 'bg-green-200 text-green-800' : 'bg-red-100 text-red-600' }}">
+                                class="px-2 py-1 text-sm rounded-full {{ $admin->activo ? 'bg-green-200 text-green-800' : 'bg-red-100 text-red-600' }}">
                                 {{ $admin->activo ? 'Activo' : 'Inactivo' }}
                             </span>
+                            @if ($admin->superadmin)
+                                <span class="px-2 py-1 text-sm rounded-full bg-amber-200 text-amber-800">SuperAdmin </span>
+                            @endif
                         </div>
 
                         <div class="text-sm text-gray-600 space-y-1">

--- a/resources/views/admin/administradores/index.blade.php
+++ b/resources/views/admin/administradores/index.blade.php
@@ -9,8 +9,7 @@
         @else
             <flux:tooltip content="No tienes permiso para realizar esta acción">
                 <div>
-                    <flux:button disabled icon="plus"
-                        class="text-black rounded-3xl! hover:bg-verde-oliva/70">
+                    <flux:button disabled icon="plus" class="text-black rounded-3xl! hover:bg-verde-oliva/70">
                         Nuevo Administrador
                     </flux:button>
                 </div>
@@ -25,29 +24,30 @@
                 <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
             @endif
 
-            <div class="overflow-hidden rounded-lg border-1">
-                <table class="min-w-full border-separate border-spacing-0 text-sm">
+            <div class="overflow-auto rounded-lg border hidden md:block">
+                <table class="w-full">
                     <thead class="bg-gray-200 text-azul-profundo">
                         <tr>
-                            <th class="px-4 py-2 text-left">ID</th>
-                            <th class="px-4 py-2 text-left">Nombre</th>
-                            <th class="px-4 py-2 text-left">Correo</th>
-                            <th class="px-4 py-2 text-left">Último Cambio</th>
-                            <th class="px-4 py-2 text-left">Creación</th>
-                            <th class="px-4 py-2 text-left">Activo</th>
-                            <th class="px-4 py-2 text-right">Acciones Rápidas</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">ID</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">Nombre</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">Correo</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">Último Cambio</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">Creación</th>
+                            <th class="p-2 font-semibold tracking-wide text-left">Activo</th>
+                            <th class="p-2 font-semibold tracking-wide text-right">Acciones Rápidas</th>
                         </tr>
                     </thead>
-                    @foreach ($administradores as $admin)
-                        <tbody class="bg-white text-[#3D3C63]">
-                            <tr class="hover:bg-[#FAFAFA]">
-                                <td class="px-4 py-2">{{ $admin->id }}</td>
-                                <td class="px-4 py-2">{{ $admin->nombre_admin }}</td>
-                                <td class="px-4 py-2">{{ $admin->correo_admin }}</td>
-                                <td class="px-4 py-2">{{ $admin->ultimo_cambio ?? 'No ha hecho cambios aún' }}</td>
-                                <td class="px-4 py-2">{{ $admin->created_at }}</td>
-                                <td class="px-4 py-2">{{ $admin->activo ? 'Si' : 'No' }}</td>
-                                <td class="px-4 py-2 text-right space-x-2">
+                    <tbody class="divide-y divide-gray-100">
+                        @foreach ($administradores as $admin)
+                            <tr class="odd:bg-white even:bg-gray-100">
+                                <td class="p-3 text-gray-700 font-bold whitespace-nowrap">#{{ $admin->id }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->nombre_admin }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->correo_admin }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap">
+                                    {{ $admin->ultimo_cambio ?? 'No ha hecho cambios aún' }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->created_at }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap">{{ $admin->activo ? 'Si' : 'No' }}</td>
+                                <td class="p-3 text-gray-700 whitespace-nowrap text-right space-x-2">
                                     <flux:button href="{{ route('administradores.show', $admin->id) }}" tooltip="Detalles"
                                         icon="list-bullet" class="text-blue-600!" />
 
@@ -60,9 +60,50 @@
                                     @endcan
                                 </td>
                             </tr>
-                        </tbody>
-                    @endforeach
+                        @endforeach
+                    </tbody>
                 </table>
+            </div>
+
+            <!-- Tarjetas para pantallas móviles -->
+            <div class="grid grid-cols-1 gap-4 md:hidden">
+                @foreach ($administradores as $admin)
+                    <div class="bg-gray-50 border rounded-xl p-4 space-y-4">
+                        <div class="flex items-center justify-between">
+                            <div>
+                                <h2 class="font-sans! text-lg font-semibold text-gray-800">#{{ $admin->id }} -
+                                    {{ $admin->nombre_admin }}</h2>
+                                <p class="text-sm text-gray-500">{{ $admin->correo_admin }}</p>
+                            </div>
+                            <span
+                                class="px-2 py-1 text-sm rounded-full
+                    {{ $admin->activo ? 'bg-green-200 text-green-800' : 'bg-red-100 text-red-600' }}">
+                                {{ $admin->activo ? 'Activo' : 'Inactivo' }}
+                            </span>
+                        </div>
+
+                        <div class="text-sm text-gray-600 space-y-1">
+                            <div><span class="font-medium">Creado:</span> {{ $admin->created_at }}</div>
+                            <div><span class="font-medium">Último cambio:</span>
+                                {{ $admin->ultimo_cambio ?? 'No ha hecho cambios aún' }}</div>
+                        </div>
+
+                        <div class="flex justify-end items-center space-x-2 pt-2">
+                            <span class="text-gray-700 font-bold">Acciones Rápidas: </span>
+                            <flux:button href="{{ route('administradores.show', $admin->id) }}" tooltip="Detalles"
+                                icon="list-bullet" class="text-blue-600!" />
+
+                            @can('update', App\Models\Administrador::class)
+                                <flux:button href="{{ route('administradores.edit', $admin->id) }}" tooltip="Editar Datos"
+                                    icon="pencil-square" class="text-blue-600!" />
+                            @endcan
+
+                            @can('disable', App\Models\Administrador::class)
+                                <flux:button tooltip="Desactivar Admin" icon="eye-slash" class="text-red-600!" />
+                            @endcan
+                        </div>
+                    </div>
+                @endforeach
             </div>
         </div>
     @else

--- a/resources/views/admin/administradores/index.blade.php
+++ b/resources/views/admin/administradores/index.blade.php
@@ -7,10 +7,14 @@
                 Nuevo Administrador
             </flux:button>
         @else
-            <flux:button disabled icon="plus" variant="primary"
-                class="text-white bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
-                Nuevo Administrador
-            </flux:button>
+            <flux:tooltip content="No tienes permiso para realizar esta acción">
+                <div>
+                    <flux:button disabled icon="plus"
+                        class="text-black rounded-3xl! hover:bg-verde-oliva/70">
+                        Nuevo Administrador
+                    </flux:button>
+                </div>
+            </flux:tooltip>
         @endcan
     </x-panel.header>
 

--- a/resources/views/admin/administradores/index.blade.php
+++ b/resources/views/admin/administradores/index.blade.php
@@ -17,6 +17,10 @@
     @can('viewAny', App\Models\Administrador::class)
         <div class="py-4 space-y-2 mx-auto">
 
+            @if (session('success'))
+                <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
+            @endif
+
             <div class="overflow-hidden rounded-lg border-1">
                 <table class="min-w-full border-separate border-spacing-0 text-sm">
                     <thead class="bg-gray-200 text-azul-profundo">

--- a/resources/views/admin/administradores/show.blade.php
+++ b/resources/views/admin/administradores/show.blade.php
@@ -32,6 +32,24 @@
 
         <h2 class="mb-4 text-2xl text-azul-profundo font-bold">Permisos Actuales</h2>
 
+        <div class="mb-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            @foreach ($permisos_actuales as $categoria => $permisos)
+                <div class="bg-white border rounded-xl overflow-hidden">
+                    <div class="bg-gray-100 px-4 py-2 font-semibold text-azul-profundo text-sm border-b">
+                        {{ $categoria }}
+                    </div>
+                    <div class="flex flex-wrap gap-2 px-4 py-3">
+                        @foreach ($permisos as $permiso)
+                            <span
+                                class="inline-block text-xs bg-verde-oliva/10 text-verde-oliva font-medium px-3 py-1 rounded-full">
+                                {{ $permiso->nombre_permiso }}
+                            </span>
+                        @endforeach
+                    </div>
+                </div>
+            @endforeach
+        </div>
+
         <h2 class="mb-4 text-2xl text-azul-profundo font-bold">Ultimas acciones</h2>
 
         <div class="mt-4 overflow-hidden rounded-lg border-1">

--- a/resources/views/admin/administradores/show.blade.php
+++ b/resources/views/admin/administradores/show.blade.php
@@ -22,11 +22,19 @@
             </div>
             <div class="bg-gray-50 rounded-lg p-4 border-1">
                 <p class="text-gray-500 mb-1">Estado</p>
-                @if ($admin->activo)
-                    <p class="font-medium text-green-600">Activo</p>
-                @else
-                    <p class="font-medium text-red-600">Inactivo</p>
-                @endif
+                <span
+                    class="px-6 py-1 text-sm font-bold rounded-full
+                        {{ $admin->activo ? 'bg-green-200 text-green-800 border border-green-300' : 'bg-red-100 text-red-600 border border-red-300' }}">
+                    {{ $admin->activo ? 'Activo' : 'Inactivo' }}
+                </span>
+            </div>
+            <div class="bg-gray-50 rounded-lg p-4 border-1">
+                <p class="text-gray-500 mb-1">Rol</p>
+                <span
+                    class="px-6 py-1 text-sm font-bold rounded-full
+                        {{ $admin->superadmin ? 'bg-amber-200 text-amber-800 border border-amber-300' : 'bg-gray-200 border border-gray-300' }}">
+                    {{ $admin->superadmin ? 'Super Admin' : 'Admin Común' }}
+                </span>
             </div>
         </div>
 

--- a/resources/views/admin/administradores/show.blade.php
+++ b/resources/views/admin/administradores/show.blade.php
@@ -32,7 +32,7 @@
 
         <h2 class="mb-4 text-2xl text-azul-profundo font-bold">Permisos Actuales</h2>
 
-        <div class="mb-4 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div class="mb-4 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-6">
             @foreach ($permisos_actuales as $categoria => $permisos)
                 <div class="bg-white border rounded-xl overflow-hidden">
                     <div class="bg-gray-100 px-4 py-2 font-semibold text-azul-profundo text-sm border-b">

--- a/resources/views/admin/categorias/index.blade.php
+++ b/resources/views/admin/categorias/index.blade.php
@@ -1,75 +1,93 @@
 <x-layouts.app :title="__('Dashboard')">
 
     <x-panel.header nombre_header="Categorías">
-        <flux:button href="/admin/categorias/create" icon="plus" variant="primary"
-            class="text-white bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
-            Nueva Categoría
-        </flux:button>
+        @can('create', App\Models\Categoria::class)
+            <flux:button href="/admin/categorias/create" icon="plus" variant="primary"
+                class="text-white bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
+                Nueva Categoría
+            </flux:button>
+        @else
+            <flux:tooltip content="No tienes permiso para esta acción">
+                <div>
+                    <flux:button disabled icon="plus"
+                        class="text-black bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
+                        Nueva Categoría
+                    </flux:button>
+                </div>
+            </flux:tooltip>
+        @endcan
     </x-panel.header>
 
-    <div class="py-4 space-y-2 mx-auto">
+    @can('viewAny', App\Models\Categoria::class)
+        <div class="py-4 space-y-2 mx-auto">
 
-        @if (session('success'))
-            <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
-        @endif
+            @if (session('success'))
+                <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
+            @endif
 
-        @foreach ($categorias as $categoria)
-            <div
-                class="bg-white border-2 rounded-xl p-3 flex flex-col md:flex-row items-center justify-between gap-4">
+            @foreach ($categorias as $categoria)
+                <div class="bg-white border-2 rounded-xl p-3 flex flex-col md:flex-row items-center justify-between gap-4">
 
-                <!-- Info de la categoría -->
-                <div class="flex-1">
-                    <h2 class="text-lg font-semibold text-gray-800">{{ $categoria->nombre_categoria }}</h2>
-                </div>
+                    <!-- Info de la categoría -->
+                    <div class="flex-1">
+                        <h2 class="text-lg font-semibold text-gray-800">{{ $categoria->nombre_categoria }}</h2>
+                    </div>
 
-                <!-- Botón editar -->
-                <a href="{{ route('categorias.edit', $categoria->id) }}">
-                    <button
-                        class="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition">
-                        Editar
-                    </button>
-                </a>
+                    <!-- Botón editar -->
+                    @can('update', App\Models\Categoria::class)
+                        <a href="{{ route('categorias.edit', $categoria->id) }}">
+                            <button class="px-4 py-2 bg-blue-600 text-white text-sm rounded-lg hover:bg-blue-700 transition">
+                                Editar
+                            </button>
+                        </a>
+                    @endcan
 
-                <!-- Botón eliminar -->
-                <button data-bs-toggle="modal" data-bs-target="#confirmDelete{{ $categoria->id }}"
-                    class="px-4 py-2 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700 transition">
-                    Eliminar
-                </button>
+                    <!-- Botón eliminar -->
+                    @can('delete', App\Models\Categoria::class)
+                        <button data-bs-toggle="modal" data-bs-target="#confirmDelete{{ $categoria->id }}"
+                            class="px-4 py-2 bg-red-600 text-white text-sm rounded-lg hover:bg-red-700 transition">
+                            Eliminar
+                        </button>
+                    @endcan
 
-                <!-- Modal eliminar -->
-                <div class="modal fade fixed top-0 left-0 w-full h-full bg-black/50 z-50 hidden"
-                    id="confirmDelete{{ $categoria->id }}" tabindex="-1" aria-hidden="true">
-                    <div class="modal-dialog relative top-1/4 mx-auto max-w-md">
-                        <div class="modal-content bg-white rounded-lg shadow-lg p-6">
-                            <div class="modal-header flex justify-between items-center">
-                                <h5 class="text-xl font-medium">Confirmar eliminación</h5>
-                                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-                            </div>
-                            <div class="modal-body mt-4">
-                                <p>¿Estás seguro de que deseas eliminar
-                                    <strong>{{ $categoria->nombre_categoria }}</strong>?
-                                </p>
-                            </div>
-                            <div class="modal-footer flex justify-end mt-4 space-x-2">
-                                <form action="{{ route('categorias.destroy', $categoria->id) }}" method="POST">
-                                    @csrf
-                                    @method('DELETE')
-                                    <button type="submit"
-                                        class="bg-red-600 hover:bg-red-700 text-white font-semibold py-1.5 px-4 rounded text-sm">
-                                        Sí, eliminar</button>
-                                </form>
-                                <button type="button"
-                                    class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-1.5 px-4 rounded text-sm"
-                                    data-bs-dismiss="modal">Cancelar</button>
+                    <!-- Modal eliminar -->
+                    <div class="modal fade fixed top-0 left-0 w-full h-full bg-black/50 z-50 hidden"
+                        id="confirmDelete{{ $categoria->id }}" tabindex="-1" aria-hidden="true">
+                        <div class="modal-dialog relative top-1/4 mx-auto max-w-md">
+                            <div class="modal-content bg-white rounded-lg shadow-lg p-6">
+                                <div class="modal-header flex justify-between items-center">
+                                    <h5 class="text-xl font-medium">Confirmar eliminación</h5>
+                                    <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+                                </div>
+                                <div class="modal-body mt-4">
+                                    <p>¿Estás seguro de que deseas eliminar
+                                        <strong>{{ $categoria->nombre_categoria }}</strong>?
+                                    </p>
+                                </div>
+                                <div class="modal-footer flex justify-end mt-4 space-x-2">
+                                    <form action="{{ route('categorias.destroy', $categoria->id) }}" method="POST">
+                                        @csrf
+                                        @method('DELETE')
+                                        <button type="submit"
+                                            class="bg-red-600 hover:bg-red-700 text-white font-semibold py-1.5 px-4 rounded text-sm">
+                                            Sí, eliminar</button>
+                                    </form>
+                                    <button type="button"
+                                        class="bg-gray-300 hover:bg-gray-400 text-gray-800 font-semibold py-1.5 px-4 rounded text-sm"
+                                        data-bs-dismiss="modal">Cancelar</button>
+                                </div>
                             </div>
                         </div>
                     </div>
+
                 </div>
-
+            @endforeach
+        </div>
+    @else
+        <div class="flex items-center justify-center h-64">
+            <div class="text-center">
+                <p class="text-lg font-semibold text-gray-600">No tienes permiso para ver las categorías.</p>
             </div>
-        @endforeach
-    </div>
-
-
-
+        </div>
+    @endcan
 </x-layouts.app>

--- a/resources/views/admin/categorias/index.blade.php
+++ b/resources/views/admin/categorias/index.blade.php
@@ -9,23 +9,9 @@
 
     <div class="py-4 space-y-2 mx-auto">
 
-        @foreach (['success_create', 'success_update', 'success_delete'] as $flash)
-            @if (session($flash))
-                <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
-                    role="alert">
-                    <strong class="font-bold">¡Éxito!</strong>
-                    <span class="block sm:inline">{{ session($flash) }}</span>
-                    <span class="absolute top-0 bottom-0 right-0 px-4 py-3">
-                        <svg class="fill-current h-6 w-6 text-green-500" role="button"
-                            xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"
-                            onclick="this.parentElement.parentElement.style.display='none';">
-                            <title>Cerrar</title>
-                            <path d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 2.65a1.2 1.2 0 1 1-1.697-1.697L8.303 10l-2.651-2.651a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-2.651a1.2 1.2 0 1 1 1.697 1.697L11.697 10l2.651 2.651a1.2 1.2 0 0 1 0 1.697z" />
-                        </svg>
-                    </span>
-                </div>
-            @endif
-        @endforeach
+        @if (session('success'))
+            <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
+        @endif
 
         @foreach ($categorias as $categoria)
             <div

--- a/resources/views/admin/productos/index.blade.php
+++ b/resources/views/admin/productos/index.blade.php
@@ -7,10 +7,14 @@
                 Nuevo Producto
             </flux:button>
         @else
-            <flux:button disabled icon="plus" variant="primary"
-                class="text-white bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
-                Nuevo Producto
-            </flux:button>
+            <flux:tooltip content="No tienes permiso para esta acción">
+                <div>
+                    <flux:button disabled icon="plus"
+                        class="text-black bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
+                        Nuevo Producto
+                    </flux:button>
+                </div>
+            </flux:tooltip>
         @endcan
     </x-panel.header>
 

--- a/resources/views/admin/productos/index.blade.php
+++ b/resources/views/admin/productos/index.blade.php
@@ -17,50 +17,8 @@
     @can('viewAny', App\Models\Producto::class)
         <div class="py-4 space-y-2 mx-auto">
 
-            @if (session('success_create'))
-                <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
-                    role="alert">
-                    <strong class="font-bold">¡Éxito!</strong>
-                    <span class="block sm:inline">{{ session('success_create') }}</span>
-                    <span class="absolute top-0 bottom-0 right-0 px-4 py-3">
-                        <svg class="fill-current h-6 w-6 text-green-500" role="button" xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20" onclick="this.parentElement.parentElement.style.display='none';">
-                            <title>Cerrar</title>
-                            <path
-                                d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 2.65a1.2 1.2 0 1 1-1.697-1.697L8.303 10l-2.651-2.651a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-2.651a1.2 1.2 0 1 1 1.697 1.697L11.697 10l2.651 2.651a1.2 1.2 0 0 1 0 1.697z" />
-                        </svg>
-                    </span>
-                </div>
-            @endif
-            @if (session('success_update'))
-                <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
-                    role="alert">
-                    <strong class="font-bold">¡Éxito!</strong>
-                    <span class="block sm:inline">{{ session('success_update') }}</span>
-                    <span class="absolute top-0 bottom-0 right-0 px-4 py-3">
-                        <svg class="fill-current h-6 w-6 text-green-500" role="button" xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20" onclick="this.parentElement.parentElement.style.display='none';">
-                            <title>Cerrar</title>
-                            <path
-                                d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 2.65a1.2 1.2 0 1 1-1.697-1.697L8.303 10l-2.651-2.651a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-2.651a1.2 1.2 0 1 1 1.697 1.697L11.697 10l2.651 2.651a1.2 1.2 0 0 1 0 1.697z" />
-                        </svg>
-                    </span>
-                </div>
-            @endif
-            @if (session('success_delete'))
-                <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded relative mb-4"
-                    role="alert">
-                    <strong class="font-bold">¡Éxito!</strong>
-                    <span class="block sm:inline">{{ session('success_delete') }}</span>
-                    <span class="absolute top-0 bottom-0 right-0 px-4 py-3">
-                        <svg class="fill-current h-6 w-6 text-green-500" role="button" xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 20 20" onclick="this.parentElement.parentElement.style.display='none';">
-                            <title>Cerrar</title>
-                            <path
-                                d="M14.348 14.849a1.2 1.2 0 0 1-1.697 0L10 11.819l-2.651 2.65a1.2 1.2 0 1 1-1.697-1.697L8.303 10l-2.651-2.651a1.2 1.2 0 1 1 1.697-1.697L10 8.183l2.651-2.651a1.2 1.2 0 1 1 1.697 1.697L11.697 10l2.651 2.651a1.2 1.2 0 0 1 0 1.697z" />
-                        </svg>
-                    </span>
-                </div>
+            @if (session('success'))
+                <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
             @endif
 
             <x-ordenamiento-y-busqueda></x-ordenamiento-y-busqueda>
@@ -71,7 +29,7 @@
 
                     <!-- Imagen -->
                     <div class="w-full md:w-20 h-20 bg-gray-100 rounded-lg overflow-hidden flex-shrink-0">
-                        <img src="{{ $producto->imagen_url ? asset('storage/'.$producto->imagen_url) : '/images/placeholder-product.jpg' }}"
+                        <img src="{{ $producto->imagen_url ? asset('storage/' . $producto->imagen_url) : '/images/placeholder-product.jpg' }}"
                             alt="{{ $producto->nombre_producto }}" class="w-full h-full object-cover">
                     </div>
 
@@ -83,25 +41,26 @@
                         <div class="text-sm text-gray-600">
                             <span class="font-medium">Precio:</span> ${{ $producto->precio }}<br>
                             <span class="font-medium">Stock:</span> {{ $producto->stock_actual }} unidades<br>
-                            <span class="font-medium">Categoría:</span> {{ $producto->categoria->nombre_categoria ?? 'SIN CATEGORÍA' }}
+                            <span class="font-medium">Categoría:</span>
+                            {{ $producto->categoria->nombre_categoria ?? 'SIN CATEGORÍA' }}
                         </div>
                     </div>
 
-                    <flux:button href="/admin/movimientos/salida/{{ $producto->id }}/create-venta"
-                        icon="banknotes" class="text-green-700!">
+                    <flux:button href="/admin/movimientos/salida/{{ $producto->id }}/create-venta" icon="banknotes"
+                        class="text-green-700!">
                         Venta Rápida
                     </flux:button>
 
                     @can('update', App\Models\Producto::class)
                         <!-- Botón editar -->
-                        <flux:button href="{{ route('productos.edit', $producto->id) }}"
-                            icon="pencil-square" class="text-blue-700!">
+                        <flux:button href="{{ route('productos.edit', $producto->id) }}" icon="pencil-square"
+                            class="text-blue-700!">
                             Editar
                         </flux:button>
                     @endcan
                     @can('delete', App\Models\Producto::class)
-                        <flux:button data-bs-toggle="modal" data-bs-target="#confirmDelete{{ $producto->id }}"
-                            icon="trash" class="text-red-500!">
+                        <flux:button data-bs-toggle="modal" data-bs-target="#confirmDelete{{ $producto->id }}" icon="trash"
+                            class="text-red-500!">
                             Eliminar
                         </flux:button>
                     @endcan

--- a/resources/views/admin/usuarios/index.blade.php
+++ b/resources/views/admin/usuarios/index.blade.php
@@ -9,6 +9,10 @@
 
     <div class="py-4 space-y-2 mx-auto">
 
+        @if (session('success'))
+            <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
+        @endif
+
         <div class="overflow-hidden rounded-lg border-1">
             <table class="min-w-full border-separate border-spacing-0 text-sm">
                 <thead class="bg-gray-200 text-azul-profundo">
@@ -56,7 +60,7 @@
                                 <flux:modal.close>
                                     <flux:button variant="filled">{{ __('Cancelar') }}</flux:button>
                                 </flux:modal.close>
-                            
+
                                 <flux:button variant="danger" type="submit">{{ __('Eliminar cuenta') }}</flux:button>
                             </div>
                         </div>

--- a/resources/views/admin/usuarios/index.blade.php
+++ b/resources/views/admin/usuarios/index.blade.php
@@ -1,81 +1,102 @@
 <x-layouts.app :title="__('Dashboard')">
 
     <x-panel.header nombre_header="Usuarios">
-        <flux:button href="/admin/usuarios/create" icon="plus" variant="primary"
-            class="text-white bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
-            Nuevo Usuario
-        </flux:button>
+        @can('create', App\Models\User::class)
+            <flux:button href="/admin/usuarios/create" icon="plus" variant="primary"
+                class="text-white bg-verde-oliva rounded-3xl! hover:bg-verde-oliva/70">
+                Nuevo Usuario
+            </flux:button>
+        @else
+            <flux:tooltip content="No tienes permiso para realizar esta acción">
+                <div>
+                    <flux:button disabled icon="plus" class="text-black rounded-3xl! hover:bg-verde-oliva/70">
+                        Nuevo Usuario
+                    </flux:button>
+                </div>
+            </flux:tooltip>
+        @endcan
     </x-panel.header>
 
-    <div class="py-4 space-y-2 mx-auto">
-
-        @if (session('success'))
-            <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
-        @endif
-
-        <div class="overflow-hidden rounded-lg border-1">
-            <table class="min-w-full border-separate border-spacing-0 text-sm">
-                <thead class="bg-gray-200 text-azul-profundo">
-                    <tr>
-                        <th class="px-4 py-2 text-left">ID</th>
-                        <th class="px-4 py-2 text-left">Nombre</th>
-                        <th class="px-4 py-2 text-left">Correo</th>
-                        <th class="px-4 py-2 text-left">Último Cambio</th>
-                        <th class="px-4 py-2 text-left">Creación</th>
-                        <th class="px-4 py-2 text-right">Acciones Rápidas</th>
-                    </tr>
-                </thead>
-                @foreach ($usuarios as $usuario)
-                <tbody class="bg-white text-[#3D3C63]">
-                    <tr class="hover:bg-[#FAFAFA]">
-                        <td class="px-4 py-2">{{ $usuario->id }}</td>
-                        <td class="px-4 py-2">{{ $usuario->name }}</td>
-                        <td class="px-4 py-2">{{ $usuario->email }}</td>
-                        <td class="px-4 py-2">{{ $usuario->ultimo_cambio ?? 'No ha hecho cambios aún' }}</td>
-                        <td class="px-4 py-2">{{ $usuario->created_at }}</td>
-                        <td class="px-4 py-2 text-right space-x-2">
-                            <flux:button href="{{ route('usuarios.show', $usuario->id) }}" tooltip="Detalles" icon="list-bullet" class="text-blue-600!"></flux:button>
-                            <flux:button href="{{ route('usuarios.edit', $usuario->id) }}" tooltip="Editar Datos" icon="pencil-square" class="text-blue-600!"></flux:button>
-                            <flux:modal.trigger name="eliminarUsuarioModal" onclick="prepararEliminacion({{ $usuario->id }})" class="text-red-600!">
-                                <flux:button tooltip="Eliminar cuenta" icon="trash" class="text-red-600!"></flux:button>
-                            </flux:modal.trigger>
-
-                        </td>
-                    </tr>
-                </tbody>
-                @endforeach
-                <flux:modal name="eliminarUsuarioModal" :show="$errors->isNotEmpty()" focusable class="max-w-lg">
-                    <form method="POST" id="formEliminarUsuario" class="space-y-6">
-                        @csrf
-                        @method('DELETE')
-
-                        <div class="space-y-6">
-                            <div>
-                                <flux:heading size="lg">{{ __('¿Estás segur@ que quieres eliminar esta cuenta?') }}</flux:heading>
-                                <flux:subheading>
-                                    {{ __('Una vez que elimines esta cuenta, todos sus datos y recursos serán permanentemente eliminados.') }}
-                                </flux:subheading>
-                            </div>
-                            <div class="flex justify-end space-x-2 rtl:space-x-reverse">
-                                <flux:modal.close>
-                                    <flux:button variant="filled">{{ __('Cancelar') }}</flux:button>
-                                </flux:modal.close>
-
-                                <flux:button variant="danger" type="submit">{{ __('Eliminar cuenta') }}</flux:button>
-                            </div>
-                        </div>
-                    </form>
-                </flux:modal>
-            </table>
+    @cannot('viewAny', App\Models\User::class)
+        <div class="flex items-center justify-center h-64">
+            <div class="text-center">
+                <p class="text-lg font-semibold text-gray-600">No tienes permisos para ver los usuarios.</p>
+            </div>
         </div>
-    </div>
+    @else
+        <div class="py-4 space-y-2 mx-auto">
 
-<script>
-    function prepararEliminacion(usuarioId) {
-        const form = document.getElementById('formEliminarUsuario');
-        form.action = `/admin/usuarios/${usuarioId}`; // o cambia la ruta según sea necesario
-    }
-</script>
+            @if (session('success'))
+                <x-mensaje-accion icon="check-circle" variant="success" heading="{{ session('success') }}" />
+            @endif
 
+            <div class="overflow-hidden rounded-lg border-1">
+                <table class="min-w-full border-separate border-spacing-0 text-sm">
+                    <thead class="bg-gray-200 text-azul-profundo">
+                        <tr>
+                            <th class="px-4 py-2 text-left">ID</th>
+                            <th class="px-4 py-2 text-left">Nombre</th>
+                            <th class="px-4 py-2 text-left">Correo</th>
+                            <th class="px-4 py-2 text-left">Último Cambio</th>
+                            <th class="px-4 py-2 text-left">Creación</th>
+                            <th class="px-4 py-2 text-right">Acciones Rápidas</th>
+                        </tr>
+                    </thead>
+                    @foreach ($usuarios as $usuario)
+                        <tbody class="bg-white text-[#3D3C63]">
+                            <tr class="hover:bg-[#FAFAFA]">
+                                <td class="px-4 py-2">{{ $usuario->id }}</td>
+                                <td class="px-4 py-2">{{ $usuario->name }}</td>
+                                <td class="px-4 py-2">{{ $usuario->email }}</td>
+                                <td class="px-4 py-2">{{ $usuario->ultimo_cambio ?? 'No ha hecho cambios aún' }}</td>
+                                <td class="px-4 py-2">{{ $usuario->created_at }}</td>
+                                <td class="px-4 py-2 text-right space-x-2">
+                                    <flux:button href="{{ route('usuarios.show', $usuario->id) }}" tooltip="Detalles" icon="list-bullet" class="text-blue-600!"/>
+                                    @can('update', App\Models\User::class)
+                                        <flux:button href="{{ route('usuarios.edit', $usuario->id) }}" tooltip="Editar Datos" icon="pencil-square" class="text-blue-600!"/>
+                                    @endcan
+                                    @can('delete', App\Models\User::class)
+                                        <flux:modal.trigger name="eliminarUsuarioModal" onclick="prepararEliminacion({{ $usuario->id }})" class="text-red-600!">
+                                            <flux:button tooltip="Eliminar cuenta" icon="trash" class="text-red-600!"/>
+                                        </flux:modal.trigger>
+                                    @endcan
 
+                                </td>
+                            </tr>
+                        </tbody>
+                    @endforeach
+                    <flux:modal name="eliminarUsuarioModal" :show="$errors->isNotEmpty()" focusable class="max-w-lg">
+                        <form method="POST" id="formEliminarUsuario" class="space-y-6">
+                            @csrf
+                            @method('DELETE')
+
+                            <div class="space-y-6">
+                                <div>
+                                    <flux:heading size="lg">{{ __('¿Estás segur@ que quieres eliminar esta cuenta?') }}
+                                    </flux:heading>
+                                    <flux:subheading>
+                                        {{ __('Una vez que elimines esta cuenta, todos sus datos y recursos serán permanentemente eliminados.') }}
+                                    </flux:subheading>
+                                </div>
+                                <div class="flex justify-end space-x-2 rtl:space-x-reverse">
+                                    <flux:modal.close>
+                                        <flux:button variant="filled">{{ __('Cancelar') }}</flux:button>
+                                    </flux:modal.close>
+
+                                    <flux:button variant="danger" type="submit">{{ __('Eliminar cuenta') }}</flux:button>
+                                </div>
+                            </div>
+                        </form>
+                    </flux:modal>
+                </table>
+            </div>
+        </div>
+
+        <script>
+            function prepararEliminacion(usuarioId) {
+                const form = document.getElementById('formEliminarUsuario');
+                form.action = `/admin/usuarios/${usuarioId}`; // o cambia la ruta según sea necesario
+            }
+        </script>
+    @endcannot
 </x-layouts.app>

--- a/resources/views/admin/usuarios/show.blade.php
+++ b/resources/views/admin/usuarios/show.blade.php
@@ -2,23 +2,32 @@
 
     <h2 class="mb-4 text-2xl text-azul-profundo font-bold">Detalles</h2>
 
-    <div class="mb-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-azul-profundo">
-        <div class="bg-gray-50 rounded-lg p-4 border-1">
-            <p class="text-gray-500 mb-1">Nombre</p>
-            <p class="font-medium">{{ $usuario->name }}</p>
+    @cannot('view', App\Models\User::class)
+        <div class="flex items-center justify-center h-64">
+            <div class="text-center">
+                <p class="text-lg font-semibold text-gray-600">
+                    No tienes permiso para ver los detalles de un administrador.
+                </p>
+            </div>
         </div>
-        <div class="bg-gray-50 rounded-lg p-4 border-1">
-            <p class="text-gray-500 mb-1">Correo electrónico</p>
-            <p class="font-medium">{{ $usuario->email }}</p>
+    @else
+        <div class="mb-4 grid grid-cols-1 sm:grid-cols-2 gap-4 text-azul-profundo">
+            <div class="bg-gray-50 rounded-lg p-4 border-1">
+                <p class="text-gray-500 mb-1">Nombre</p>
+                <p class="font-medium">{{ $usuario->name }}</p>
+            </div>
+            <div class="bg-gray-50 rounded-lg p-4 border-1">
+                <p class="text-gray-500 mb-1">Correo electrónico</p>
+                <p class="font-medium">{{ $usuario->email }}</p>
+            </div>
+            <div class="bg-gray-50 rounded-lg p-4 border-1">
+                <p class="text-gray-500 mb-1">Fecha de creación</p>
+                <p class="font-medium">{{ $usuario->created_at }}</p>
+            </div>
+            <div class="bg-gray-50 rounded-lg p-4 border-1">
+                <p class="text-gray-500 mb-1">Último acceso</p>
+                <p class="font-medium">{{ $usuario->ultimo_login ?? '---' }}</p>
+            </div>
         </div>
-        <div class="bg-gray-50 rounded-lg p-4 border-1">
-            <p class="text-gray-500 mb-1">Fecha de creación</p>
-            <p class="font-medium">{{ $usuario->created_at }}</p>
-        </div>
-        <div class="bg-gray-50 rounded-lg p-4 border-1">
-            <p class="text-gray-500 mb-1">Último acceso</p>
-            <p class="font-medium">{{ $usuario->ultimo_login ?? '---' }}</p>
-        </div>
-    </div>
-
+    @endcannot
 </x-layouts.navlist-show-users>

--- a/resources/views/components/layouts/navlist-show-admins.blade.php
+++ b/resources/views/components/layouts/navlist-show-admins.blade.php
@@ -8,7 +8,7 @@
 
     <div class="mt-4 flex items-start max-md:flex-col">
         <div class="me-10 w-full pb-4 md:w-[220px]">
-            <flux:navlist.group>routes/web.php
+            <flux:navlist.group>
                 <flux:navlist.item href="/admin/administradores/{{ $admin->id }}"
                     class="data-current:bg-gray-200! hover:underline!">Detalles</flux:navlist.item>
 
@@ -20,12 +20,12 @@
                     <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/edit-permisos"
                         class="data-current:bg-gray-200! hover:underline!">Editar Permisos </flux:navlist.item>
                 @endif
+                <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Cambiar Contraseña </flux:navlist.item>
+                <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/historial" class="data-current:bg-gray-200! hover:underline!">Historial de Acciones</flux:navlist.item>
                 @can('disable', App\Models\Administrador::class)
-                    <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Desactivar Admin
-                    </flux:navlist.item>
+                <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Desactivar Admin
+                </flux:navlist.item>
                 @endcan
-                <!-- <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Cambiar Contraseña </flux:navlist.item> -->
-                <!-- <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/historial" class="data-current:bg-gray-200! hover:underline!">Historial</flux:navlist.item> -->
             </flux:navlist.group>
         </div>
 

--- a/resources/views/components/layouts/navlist-show-admins.blade.php
+++ b/resources/views/components/layouts/navlist-show-admins.blade.php
@@ -20,12 +20,45 @@
                     <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/edit-permisos"
                         class="data-current:bg-gray-200! hover:underline!">Editar Permisos </flux:navlist.item>
                 @endif
-                <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Cambiar Contraseña </flux:navlist.item>
-                <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/historial" class="data-current:bg-gray-200! hover:underline!">Historial de Acciones</flux:navlist.item>
-                @can('disable', App\Models\Administrador::class)
-                <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Desactivar Admin
+                <flux:navlist.item href="#" class="data-current:bg-gray-200! hover:underline!">Cambiar Contraseña
                 </flux:navlist.item>
-                @endcan
+                <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/historial"
+                    class="data-current:bg-gray-200! hover:underline!">Historial de Acciones</flux:navlist.item>
+
+                <flux:separator class="my-2" />
+
+                <!-- Botón y Modal para desactivar un admin -->
+                @if (!$admin->superadmin && Auth::user('admin')->can('disable', App\Models\Administrador::class))
+                    @if ($admin->activo)
+                        <flux:modal.trigger name="disable-admin">
+                            <flux:navlist.item class="text-red-500! hover:underline!">
+                                Desactivar Admin
+                            </flux:navlist.item>
+                        </flux:modal.trigger>
+
+                        <flux:modal name="disable-admin" class="min-w-[22rem]">
+                            <div class="space-y-6">
+                                <div>
+                                    <flux:heading size="lg">¿Desactivar Administrador?</flux:heading>
+                                    <flux:text class="mt-2">
+                                        <p>Esta acción es reversible</p>
+                                    </flux:text>
+                                </div>
+                                <div class="flex gap-2">
+                                    <flux:spacer />
+                                    <flux:modal.close>
+                                        <flux:button variant="ghost">Cancelar</flux:button>
+                                    </flux:modal.close>
+                                    <flux:button href="{{ route('administradores.disable', $admin) }}" variant="danger">
+                                        Aceptar</flux:button>
+                                </div>
+                            </div>
+                        </flux:modal>
+                    @else
+                        <flux:navlist.item href="{{ route('administradores.disable', $admin) }}"
+                            class="hover:underline!">Reactivar Admin</flux:navlist.item>
+                    @endif
+                @endif
             </flux:navlist.group>
         </div>
 

--- a/resources/views/components/layouts/navlist-show-admins.blade.php
+++ b/resources/views/components/layouts/navlist-show-admins.blade.php
@@ -24,11 +24,16 @@
                 </flux:navlist.item>
                 <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/historial"
                     class="data-current:bg-gray-200! hover:underline!">Historial de Acciones</flux:navlist.item>
-
-                <flux:separator class="my-2" />
+                @if (!$admin->superadmin)
+                    <flux:navlist.item href="/admin/administradores/{{ $admin->id }}/delete"
+                        class="data-current:bg-gray-200! hover:underline!">Eliminar Admin</flux:navlist.item>
+                @endif
 
                 <!-- Botón y Modal para desactivar un admin -->
                 @if (!$admin->superadmin && Auth::user('admin')->can('disable', App\Models\Administrador::class))
+
+                    <flux:separator class="my-2" />
+
                     @if ($admin->activo)
                         <flux:modal.trigger name="disable-admin">
                             <flux:navlist.item class="text-red-500! hover:underline!">

--- a/resources/views/components/mensaje-accion.blade.php
+++ b/resources/views/components/mensaje-accion.blade.php
@@ -1,0 +1,14 @@
+@props([
+    'icon' => null,
+    'variant' => null,
+    'heading' => null,
+])
+
+<flux:callout :icon="$icon" :variant="$variant" inline x-data="{ visible: true }" x-show="visible" class="mb-4">
+    <flux:callout.heading class="flex gap-2 @max-md:flex-col items-start">
+        {{ $heading }}
+    </flux:callout.heading>
+    <x-slot name="controls">
+        <flux:button icon="x-mark" variant="ghost" x-on:click="visible = false" />
+    </x-slot>
+</flux:callout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -11,6 +11,8 @@ use App\Http\Controllers\ProductoUserController;
 use App\Livewire\Settings\Appearance;
 use App\Livewire\Settings\Password;
 use App\Livewire\Settings\Profile;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
 // Vista de prueba
@@ -26,7 +28,7 @@ Route::get('/productos/categorias/{categoria}', [CategoriaUserController::class,
 Route::get('/productos/{id}', [ProductoUserController::class, 'show']);
 
 // Rutas a las que solo puede acceder el admin
-Route::middleware(['auth:admin', 'verified'])->prefix('admin')->group(function () {
+Route::middleware(['auth:admin', 'verified', 'can:admin-activo'])->prefix('admin')->group(function () {
     Route::get('/dashboard', DashboardController::class);
 
     Route::resource('/productos', ProductoController::class);
@@ -37,6 +39,8 @@ Route::middleware(['auth:admin', 'verified'])->prefix('admin')->group(function (
         ->name('administradores.update-permisos');
     Route::get('/administradores/{administrador}/historial', [AdministradoresController::class, 'index_historial'])
         ->name('administradores.historial');
+    Route::get('/administradores/{administrador}/disable', [AdministradoresController::class, 'disable'])
+        ->name('administradores.disable');
     Route::resource('/administradores', AdministradoresController::class)
         ->parameters(['administradores' => 'administrador']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -35,6 +35,8 @@ Route::middleware(['auth:admin', 'verified'])->prefix('admin')->group(function (
     Route::get('/administradores/{administrador}/edit-permisos', [AdministradoresController::class, 'edit_permisos']);
     Route::put('/administradores/{administrador}/update-permisos', [AdministradoresController::class, 'update_permisos'])
         ->name('administradores.update-permisos');
+    Route::get('/administradores/{administrador}/historial', [AdministradoresController::class, 'index_historial'])
+        ->name('administradores.historial');
     Route::resource('/administradores', AdministradoresController::class)
         ->parameters(['administradores' => 'administrador']);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -41,6 +41,8 @@ Route::middleware(['auth:admin', 'verified', 'can:admin-activo'])->prefix('admin
         ->name('administradores.historial');
     Route::get('/administradores/{administrador}/disable', [AdministradoresController::class, 'disable'])
         ->name('administradores.disable');
+    Route::get('/administradores/{administrador}/delete', [AdministradoresController::class, 'delete'])
+        ->name('administradores.delete');
     Route::resource('/administradores', AdministradoresController::class)
         ->parameters(['administradores' => 'administrador']);
 


### PR DESCRIPTION
Esta rama la hice principalmente para actualizar lo de las acciones, pero termine metiendo varias cosas del modulo de admins y otras cosas:

- Ahora para registrar una acción del admin, solo se debe pasar el modelo y el nombre de la acción. Aqui un ejemplo:

```php
// registrar acción del admin
Registro::registrar_accion($producto, 'Crea nuevo producto');
```

Ahora las otras cosas que aproveche de meter:

- Algunos mensajes de exito que faltaban (puede que falten algunos más)
- puse los mensajes de exito de flux, lo que limpia un poco el código
- Advertencia si no se asigna el permiso de **Ver Todo** de algo, ya que no te deja acceder a las rutas normalmente.
- Se implementaron los permisos a los modulos que faltaban.
- Añadi un modulo llamado historial de acciones para ver las acciones de los admins más detalladamente, con filtros y paginación
- Meti para que se pueda desactivar un admin. si un admin esta desactivado, se le cierran todas las rutas del panel de admin tirando error 403
- También meti que se pueda eliminar un admin, con un formulario bien riguroso para que no se borren por accidente xd.
- otros cambios menores del front. más info en los commits